### PR TITLE
Fix decryption check condition

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -279,7 +279,7 @@ in {
             builtins.concatStringsSep "\n"
             (lib.mapAttrsToList (n: v: decryptCheckScript n v.source) cfg.file)
           }
-          if [ ! -x $DECRYPTION ]; then
+          if [ -n "$DECRYPTION" ]; then
             printf "''${errorColor}''${DECRYPTION}[homeage] Check homage.identityPaths to either add an identity or remove a broken one\n''${normalColor}" 1>&2
             exit 1
           fi


### PR DESCRIPTION
I believe the decryption check can never fail.  The `if` checks for errors using `! -x $DECRYPTION`.  But `-x` checks for the existence of a file.  And indeed, some random string never exists as a file, so the printf and exit will always be skipped.

I think something like `! -z` was intended (`-z` checks for empty string).  There is also a `-n` which is equivalent to `! -z`.  So this change switches to `-n` and quotes the expansion to avoid syntax errors.